### PR TITLE
Support iOS8 Location Access type (Always and WhenInUse)

### DIFF
--- a/HiBeacons/HiBeacons-Info.plist
+++ b/HiBeacons/HiBeacons-Info.plist
@@ -31,6 +31,12 @@
 	</array>
 	<key>UIMainStoryboardFile</key>
 	<string>Main</string>
+	<key>NSLocationUsageDescription</key>
+	<string>Required for Monitoring and Ranging.</string>
+	<key>NSLocationAlwaysUsageDescription</key>
+	<string>Required for Monitoring.</string>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>Required for Ranging.</string>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
 		<string>armv7</string>

--- a/HiBeacons/NATViewController.h
+++ b/HiBeacons/NATViewController.h
@@ -28,7 +28,7 @@
 @import CoreBluetooth;
 
 @interface NATViewController : UIViewController <CLLocationManagerDelegate, CBPeripheralManagerDelegate,
-    UITableViewDataSource, UITableViewDelegate>
+    UITableViewDataSource, UITableViewDelegate, UIAlertViewDelegate>
 
 @property (nonatomic, weak) IBOutlet UITableView *beaconTableView;
 


### PR DESCRIPTION
Monitoring and Ranging fails when using Xcode 6 + iOS8. This is due to changes in Location Access Settings introduces in iOS8. Refer 'What's New in Core Location' WWDC 2014 talk.
